### PR TITLE
docs: rewrite root README + polish package README for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,195 +1,126 @@
 <div align="center">
-  <p>
-    <a href="https://docs.0xgasless.com/docs">
-      <img src="./repo-banner.png" alt="0xGasless AgentKit" width="100%" height="auto" style="object-fit: contain; max-width: 800px;">
-    </a>
-  </p>
-  <h1 style="font-size: 3em; margin-bottom: 20px;">
-    0xGasless AgentKit
-  </h1>
-  <p style="font-size: 1.2em; max-width: 600px; margin: 0 auto 20px;">
-    0xGasless AgentKit lets you build AI agents that can trade, manage funds, and interact with DeFi protocols in natural language.
-  </p>
+  <h1>0xGasless AgentKit</h1>
+  <p><b>Give your AI agent a wallet and hands.</b><br/>
+  Custodied funds, gasless stablecoin payments, and the ability to pay for real
+  work on the internet — as tools your LLM can call.</p>
 </div>
 
-<div>
-  <img src="https://img.shields.io/npm/dm/@0xgasless/agentkit" alt="NPM Downloads">
-  <img src="https://img.shields.io/github/license/0xgasless/agentkit" alt="GitHub License">
+<div align="center">
+  <img src="https://img.shields.io/npm/v/@0xgasless/agentkit" alt="npm version">
+  <img src="https://img.shields.io/npm/dm/@0xgasless/agentkit" alt="npm downloads">
+  <img src="https://img.shields.io/github/license/0xgasless/agentkit" alt="license">
 </div>
 
-<div>
-  <img src="https://img.shields.io/badge/v20.12.2-1?label=typescript&color=blue" alt="Typescript Version">
-  <img src="https://img.shields.io/pypi/pyversions/0xgasless-agentkit" alt="PyPI - Python Version">
-</div>
+## Overview
 
-## Table of Contents
-- [🚀 Overview](#-overview)
-- [✨ Key Features](#-key-features)
-- [📚 Examples](#-examples)
-- [🏗️ Repository Structure](#️-repository-structure)
-- [💻 Contributing](#-contributing)
-- [📖 Documentation](#-documentation)
-- [🔒 Security](#-security)
-- [📄 License](#-license)
+0xGasless AgentKit turns the [0xGasless platform](https://dashboard.0xgasless.com)
+into a set of tools an AI agent can call. An agent gets a **KMS-custodied wallet**
+(no private key in your process), a **server-enforced spending policy**, and the
+ability to:
 
-# 🚀 Overview
-0xGasless AgentKit is a powerful toolkit for building AI agents that can interact with blockchain networks and DeFi protocols. It enables gasless transactions and account abstraction on EVM chains, making it easier to create sophisticated blockchain applications.
+- **Pay** — send stablecoins (USDC/XSGD) and pay any [x402](https://docs.0xgasless.com/x402)
+  API on the internet, gaslessly, under spend caps.
+- **Do** — search and run tools from the 0xGasless Tool Gateway (backed by
+  Apify's actor marketplace): browse the web, scrape pages, run search — paid
+  per call from the agent's wallet.
+- **Be trusted** — mint an ERC-8004 on-chain identity, check another agent's
+  reputation before paying it, and leave feedback.
 
-**Create agents that can:**
-- Execute gasless transactions without holding native tokens
-- Transfer and trade tokens
-- Deploy smart contracts
-- Interact with DeFi protocols
-- Get wallet details and balances
-- Create and manage smart accounts
+The agent needs **zero native gas token** — the 0xGasless facilitator pays the
+gas; the agent only spends the stablecoin.
 
-**How it works**
+## Install
 
-0xGasless AgentKit leverages ERC-4337 account abstraction to enable gasless transactions:
-1. Configure your agent with a wallet
-2. Use the built-in tools for blockchain interactions
-3. Execute transactions without requiring native tokens for gas
-4. Integrate with any AI framework of your choice
+```bash
+npm install @0xgasless/agentkit
+```
 
-# ✨ Key Features
+## Quick start
 
-- **Framework-agnostic**: Common AI Agent primitives that can be used with any AI framework
-- **Python and Node.js Support**: Full support for both Python and TypeScript
-- **Gasless Transactions**: Execute transactions without holding native tokens
-- **Account Abstraction**: Built on ERC-4337 standard
-- **Multi-Chain Support**: Works across major EVM chains:
-  - BSC (56)
-  - Avalanche (43114)
-  - Base (8453)
-  - Sonic (146)
-  - Moonbeam (1284)
+```ts
+import { Agentkit, AgentkitToolkit } from "@0xgasless/agentkit";
+import { ChatOpenAI } from "@langchain/openai";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
 
-**Supported Onchain Actions:**
-- Getting wallet details and balances
-- Transferring and trading tokens
-- Coming Soon:
-  - Deploying ERC-20 tokens
-  - Deploying ERC-721 tokens and minting NFTs
-  - Buying and selling Dex Swap ERC-20 coins
-  - Wrapping ETH to WETH on Base
+// The API key (from your dashboard project) authenticates every action;
+// the wallet lives in 0xGasless KMS.
+const agentkit = await Agentkit.configureWithPlatform({
+  apiKey: process.env.OXGAS_API_KEY!,   // Dashboard → Project → Auth → API Key
+  agentId: "my-first-agent",
+  chain: "avalanche-fuji",
+});
 
-# 📚 Examples
+const tools = new AgentkitToolkit(agentkit).getTools();
+const app = createReactAgent({ llm: new ChatOpenAI({ model: "gpt-4o" }), tools });
 
-Check out [agentkit-langchain/examples](./agentkit-demo/index.ts) for inspiration and help getting started!
-- [Chatbot Typescript](./agentkit-demo/index.ts): Simple example of a Node.js Chatbot that can perform complex onchain interactions, using OpenAI.
+await app.invoke({
+  messages: [{ role: "user", content:
+    "Find a tool that can read a web page, then read https://example.com and summarize it." }],
+});
+```
 
-# 🏗️ Repository Structure
+Behind that one prompt the agent discovers a web-reader tool (free), runs it —
+paying ~$0.05 in USDC from its custodied wallet via x402, settled on Avalanche
+by the 0xGasless facilitator — and gets the page back. See the runnable
+[end-to-end demo](./agentkit-core/examples/pay-for-tools.ts).
 
-AgentKit is organized as a [monorepo](https://en.wikipedia.org/wiki/Monorepo) that contains multiple packages:
+## Two modes
+
+| Mode | Wallet | Use when |
+|---|---|---|
+| **Platform** (recommended) | KMS-custodied by 0xGasless; policy-enforced; no key in your code | You want payments, tools, identity, spend limits, audit |
+| **Self-custody** | A local private key / mnemonic via an ERC-4337 smart account | You hold the key and want classic gasless DeFi actions |
+
+## The actions
+
+**Money (platform mode)** — `x402_pay`, `pay_api` (auto-pay any 402 endpoint,
+capped), `smart_transfer`, `get_spend_status`, `get_agent_wallet`
+
+**Internet hands (Tool Gateway)** — `search_tools`, `call_tool`, `browse_web`,
+and a guarded `http_request` for free/public APIs
+
+**Trust (ERC-8004)** — `register_identity`, `check_agent_reputation`,
+`give_agent_feedback`
+
+**DeFi (both modes)** — transfers, swaps & bridges (deBridge), disperse, token
+details, market data (DexScreener), and more. Call `getAllAgentkitActions()`
+to enumerate the full set.
+
+## Supported networks
+
+Avalanche C-Chain (43114) and Avalanche Fuji (43113) are the primary, fully
+supported networks. Base (8453), Sonic (146), and BSC (56) are available for
+self-custody DeFi actions.
+
+## Repository structure
 
 ```
 ./
-├── agentkit-core/
-│   └── typescript/
-│       ├── BaseActions/
-│       │   ├── SendTransaction.ts
-│       │   ├── SignMessage.ts
-│       │   ├── EncodeFunctionData.ts
-│       │   ├── FormatHelpers.ts
-│       │   ├── GetBalance.ts
-│       │   ├── GetStatusFromUserop.ts
-│       │   └── ReadContract.ts
-│       └── Actions/
-├── agentkit-demo/
-│   ├── typescript/
-│   └── examples/
+├── agentkit-core/          the published package — @0xgasless/agentkit
+│   ├── src/                Agentkit, the toolkit, and all actions
+│   ├── examples/           runnable demos (pay-for-tools.ts)
+│   ├── README.md           package docs
+│   └── MIGRATION.md        0.0.x → 1.0 upgrade guide
+└── agentkit-demo/          a LangChain chatbot example wiring it all together
 ```
 
-## Base Actions
+## Documentation
 
-| Action | Description | File |
-|--------|-------------|------|
-| SendTransaction | Execute blockchain transactions | [SendTransaction.ts](./agentkit-core/src/BaseActions/SendTransaction.ts) |
-| SignMessage | Sign messages for authentication | [SignMessage.ts](./agentkit-core/src/BaseActions/SignMessage.ts) |
-| EncodeFunctionData | Encode function calls for smart contracts | [EncodeFunctionData.ts](./agentkit-core/src/BaseActions/EncodeFunctionData.ts) |
-| FormatHelpers | Utility functions for data formatting | [FormatHelpers.ts](./agentkit-core/src/BaseActions/FormatHelpers.ts) |
-| GetBalance | Retrieve token balances | [GetBalance.ts](./agentkit-core/src/BaseActions/GetBalance.ts) |
-| GetStatusFromUserop | Check transaction status | [GetStatusFromUserop.ts](./agentkit-core/src/BaseActions/GetStatusFromUserop.ts) |
-| ReadContract | Read data from smart contracts | [ReadContract.ts](./agentkit-core/src/BaseActions/ReadContract.ts) |
+- Package README & actions: [`agentkit-core/README.md`](./agentkit-core/README.md)
+- Migrating from 0.0.x: [`agentkit-core/MIGRATION.md`](./agentkit-core/MIGRATION.md)
+- Platform & x402: https://docs.0xgasless.com
+- Dashboard (get an API key): https://dashboard.0xgasless.com
 
-## High-Level Actions
+## Contributing
 
-| Action | Description | File | Base Actions Used |
-|--------|-------------|------|------------------|
-| SmartTransfer | Execute gasless token transfers | [smartTransferAction.ts](./agentkit-core/src/Actions/smartTransferAction.ts) | SendTransactions |
-| CheckTransaction | Monitor transaction status | [checkTransactionAction.ts](./agentkit-core/src/Actions/checkTransactionAction.ts) | CheckTransactions |
-| GetAddress | Retrieve wallet addresses | [getAddressAction.ts](./agentkit-core/src/Actions/getAddressAction.ts) | GetAddressActions|
-| GetBalance | Check token balances | [getBalanceAction.ts](./agentkit-core/src/Actions/getBalanceAction.ts) | GetBalance |
-| GetTokenDetails | Fetch token information | [getTokenDetailsAction.ts](./agentkit-core/src/Actions/getTokenDetailsAction.ts) | GetTokenDetails |
-| SmartSwap | Perform token swaps | [smartSwapAction/](./agentkit-core/src/Actions/smartSwapAction/) | SwapTransactions |
+New actions go in `agentkit-core/src/actions/` implementing the `AgentkitAction`
+interface — they're picked up automatically by `getAllAgentkitActions()` and the
+toolkit. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-# 🚀 Quickstarts
-
-## 📘 Typescript
-
-### By use case
-- **Money transmission**
-  - Send and receive payments [[SmartTransfer](./agentkit-core/src/Actions/smartTransferAction.ts)]
-  - Check transaction status [[CheckTransaction](./agentkit-core/src/Actions/checkTransactionAction.ts)]
-  - Get wallet address [[GetAddress](./agentkit-core/src/Actions/getAddressAction.ts)]
-- **Token Operations**
-  - Check token balances [[GetBalance](./agentkit-core/src/Actions/getBalanceAction.ts)]
-  - Get token details [[GetTokenDetails](./agentkit-core/src/Actions/getTokenDetailsAction.ts)]
-  - Create new tokens [[CreateFourmemeToken](./agentkit-core/src/Actions/createFourmemeTokenAction.ts)]
-- **DeFi Operations**
-  - Swap tokens without gas fees
-  - Wrap ETH to WETH
-  - Interact with DEX protocols
-
-# 🛠️ Supported Tools and Frameworks
-
-## Tools
-
-| Plugin | Tools |
-| --- | --- |
-| Smart Transfer | Execute gasless token transfers |
-| Smart Swap | Perform token swaps without gas |
-| Token Creation | Deploy new tokens |
-| Balance Check | Check token balances |
-| Transaction Monitor | Monitor transaction status |
-| Contract Reader | Read smart contract data |
-
-## Common Use Cases
-
-| Use Case | Required Actions | Description |
-|----------|-----------------|-------------|
-| Token Transfer | GetAddress, GetBalance, SmartTransfer, CheckTransaction | Complete flow for transferring tokens |
-| Token Creation | CreateFourmemeToken, GetTokenDetails | Deploy and verify new tokens |
-| Token Swap | GetBalance, SmartSwap, CheckTransaction | Swap tokens with gasless execution |
-| Balance Check | GetAddress, GetBalance | Check balances for any token |
-| Transaction Monitoring | CheckTransaction | Monitor transaction status |
-
-# 💻 Contributing
-
-AgentKit welcomes community contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
-
-Some ways you can contribute:
-- Adding new actions to the core package
-- Updating existing Langchain Toolkits or adding new ones
-- Creating new AI frameworks extensions
-- Adding tests and improving documentation
-
-# 📖 Documentation
-
-- [AgentKit Documentation](https://docs.0xgasless.com/docs)
-
-# 🔒 Security
-
-The AgentKit team takes security seriously.
-See [SECURITY.md](SECURITY.md) for more information.
-
-# 📄 License
+## License
 
 Apache-2.0
 
-# 🤝 Community
-- Follow us on [X](https://x.com/0xGasless)
-- Follow us on [LinkedIn](https://www.linkedin.com/company/0xgasless/)
+## Community
 
-
-
+- [X](https://x.com/0xGasless) · [LinkedIn](https://www.linkedin.com/company/0xgasless/)

--- a/agentkit-core/README.md
+++ b/agentkit-core/README.md
@@ -5,6 +5,12 @@
   as tools your LLM can call.</p>
 </div>
 
+<div align="center">
+  <img src="https://img.shields.io/npm/v/@0xgasless/agentkit" alt="npm version">
+  <img src="https://img.shields.io/npm/dm/@0xgasless/agentkit" alt="npm downloads">
+  <img src="https://img.shields.io/npm/l/@0xgasless/agentkit" alt="license">
+</div>
+
 ## What it is
 
 AgentKit turns the [0xGasless platform](https://dashboard.0xgasless.com) into a


### PR DESCRIPTION
- root README: fully rewritten to match 1.0 — 'wallet + hands' framing, platform vs self-custody modes, money/tools/trust action map, correct networks (Moonbeam removed, Sonic 146), accurate repo structure, links to package README + MIGRATION + the pay-for-tools demo. Removed stale content (CreateFourmemeToken, old BaseActions tables, misleading Python/PyPI badge).
- agentkit-core README: add npm badges for parity.