### PR TITLE
feat: Peer Cash actions for non-custodial USDC to fiat on Base

### DIFF
--- a/agentkit-core/package.json
+++ b/agentkit-core/package.json
@@ -41,7 +41,7 @@
     "zod": "^3.23.8",
     "@0xgasless/smart-account-sdk": "^0.0.15",
     "@0xgasless/agent": "^2.2.1",
-    "@zkp2p/cash": "^0.4.9"
+    "@zkp2p/cash": "0.4.9"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/agentkit-core/package.json
+++ b/agentkit-core/package.json
@@ -28,7 +28,7 @@
     "dev": "bun link && concurrently \"tsc --watch\" \"tsc-alias -w\"",
     "build": "tsc --project ./tsconfig.json && tsc-alias -p ./tsconfig.json",
     "prepare": "bun run format && bun run clean && bun run build",
-    "test:smoke": "node test/platform.smoke.mjs"
+    "test:smoke": "node test/platform.smoke.mjs && node test/peer-cash.smoke.mjs"
   },
   "dependencies": {
     "@langchain/core": "^0.3.40",
@@ -40,7 +40,8 @@
     "viem": "2",
     "zod": "^3.23.8",
     "@0xgasless/smart-account-sdk": "^0.0.15",
-    "@0xgasless/agent": "^2.2.1"
+    "@0xgasless/agent": "^2.2.1",
+    "@zkp2p/cash": "^0.4.9"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/agentkit-core/src/actions/PeerCashAction/capabilities.ts
+++ b/agentkit-core/src/actions/PeerCashAction/capabilities.ts
@@ -1,0 +1,64 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { capabilitiesToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient } from "./client";
+
+const PEER_CASH_CAPABILITIES_PROMPT = `
+Discovers what Peer Cash can do before you name a payout rail or currency.
+
+Peer Cash turns Base USDC into fiat: your wallet's USDC becomes a protocol-held
+order, a buyer pays the fiat to your own payment handle and proves it, and the
+escrow releases the USDC at the live Chainlink oracle rate with zero spread.
+
+USAGE
+  name : peer_cash_capabilities
+  args : none
+
+RETURNS
+  - platforms: payout platform ids with the fiat currencies each can pay, the
+    handle format it expects, and whether it needs an identity attestation
+  - destination: always Base USDC (chain 8453)
+  - amount: the protocol minimum and the recommended minimum, in USDC base units
+  - pricing: the oracle model and spread in basis points
+
+Call this first. peer_cash_estimate and peer_cash_prepare_cashout only accept a
+platform and currency listed here.
+`;
+
+export const PeerCashCapabilitiesInput = z
+  .object({})
+  .strip()
+  .describe("No arguments; Peer Cash capabilities are static");
+
+/**
+ * Reads the Peer Cash capability catalog.
+ *
+ * @param _wallet - Unused; capability discovery never touches the wallet.
+ * @param _args - Unused; the action takes no arguments.
+ * @returns The capability catalog as JSON, or a typed error message.
+ */
+export async function peerCashCapabilities(
+  _wallet: ZeroXgaslessSmartAccount,
+  _args: z.infer<typeof PeerCashCapabilitiesInput>,
+): Promise<string> {
+  try {
+    return formatResult(capabilitiesToJson(getPeerCashClient().capabilities()));
+  } catch (error) {
+    return formatError("capabilities", error);
+  }
+}
+
+/**
+ * Peer Cash capability discovery action.
+ */
+export class PeerCashCapabilitiesAction
+  implements AgentkitAction<typeof PeerCashCapabilitiesInput>
+{
+  public name = "peer_cash_capabilities";
+  public description = PEER_CASH_CAPABILITIES_PROMPT;
+  public argsSchema = PeerCashCapabilitiesInput;
+  public func = peerCashCapabilities;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/client.ts
+++ b/agentkit-core/src/actions/PeerCashAction/client.ts
@@ -1,0 +1,86 @@
+import { type CashClient, createCashClient, usdc } from "@zkp2p/cash";
+
+/**
+ * ERC-8021 analytics marker stamped on every Peer transaction these actions
+ * prepare, so Peer can attribute the order to Agentkit. It carries no funds
+ * and grants no permissions.
+ */
+const AGENTKIT_REFERRER = "0xgasless-agentkit";
+
+let client: CashClient | undefined;
+
+/**
+ * The shared Peer Cash client.
+ *
+ * Peer Cash reads need no credential and every mutating verb is exposed only
+ * through its prepare path, so this client never holds, requests, or sees a
+ * private key. `PEER_CASH_RPC_URL` overrides the public Base RPC, which is
+ * rate limited; `PEER_CASH_REFERRAL_CODE` is the six-character code from the
+ * Peer app that credits fills on the orders this agent opens.
+ *
+ * @returns The memoized `CashClient` bound to Peer production on Base.
+ */
+export function getPeerCashClient(): CashClient {
+  if (!client) {
+    const rpcUrl = process.env.PEER_CASH_RPC_URL;
+    const referralCode = process.env.PEER_CASH_REFERRAL_CODE;
+    client = createCashClient({
+      environment: "production",
+      referrer: AGENTKIT_REFERRER,
+      ...(rpcUrl ? { rpcUrl } : {}),
+      ...(referralCode ? { referralCode } : {}),
+    });
+  }
+  return client;
+}
+
+/**
+ * Pretty-print an already-serializable Peer Cash value for an LLM.
+ *
+ * @param value - A value produced by one of the `@zkp2p/cash` JSON codecs.
+ * @returns Pretty-printed JSON.
+ */
+export function formatResult(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Turn a failure into the typed, actionable message Peer Cash errors carry.
+ *
+ * Every `CashError` has a `code`, a `retryable` flag, and a `remediation`
+ * sentence, so the agent can decide whether to retry or change its input
+ * instead of guessing from a stack trace.
+ *
+ * @param verb - The Peer Cash verb that failed, for the message prefix.
+ * @param error - The thrown value.
+ * @returns A single-line error message.
+ */
+export function formatError(verb: string, error: unknown): string {
+  const source = error as {
+    message?: unknown;
+    code?: unknown;
+    retryable?: unknown;
+    remediation?: unknown;
+  };
+  const parts = [`Error: Peer Cash ${verb} failed.`];
+  if (typeof source?.code === "string") parts.push(`[${source.code}]`);
+  parts.push(typeof source?.message === "string" ? source.message : String(error));
+  if (typeof source?.remediation === "string") parts.push(`Remediation: ${source.remediation}`);
+  if (source?.retryable === true) parts.push("This error is retryable.");
+  return parts.join(" ");
+}
+
+/**
+ * Parse a decimal USDC amount into 6-decimal base units.
+ *
+ * @param amount - Decimal USDC amount, for example `"12.34"`.
+ * @returns The amount in USDC base units.
+ * @throws If the amount is not a positive decimal with at most 6 places.
+ */
+export function toUsdcBaseUnits(amount: string): bigint {
+  const value = usdc(amount.trim());
+  if (value <= 0n) {
+    throw new Error(`amount must be greater than zero; received "${amount}"`);
+  }
+  return value;
+}

--- a/agentkit-core/src/actions/PeerCashAction/client.ts
+++ b/agentkit-core/src/actions/PeerCashAction/client.ts
@@ -7,6 +7,63 @@ import { type CashClient, createCashClient, usdc } from "@zkp2p/cash";
  */
 const AGENTKIT_REFERRER = "0xgasless-agentkit";
 
+const BASE_CHAIN_ID = 8453;
+const BASE_USDC_ADDRESS = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const ERC20_APPROVE_SELECTOR = "0x095ea7b3";
+
+/**
+ * Peer production contracts used by the four custody-separated prepare paths.
+ * These addresses come from the canonical Base deployment artifacts in
+ * zkp2p/zkp2p-contracts.
+ */
+const PEER_CASH_BASE_TARGETS = new Set([
+  "0x777777779d229cdf3110e9de47943791c26300ef", // EscrowV2
+  "0x888888359e981b5225ca48fbcdceff702fc3b888", // OrchestratorV2
+  "0xbc53641b4b2504f0061d6a9426c61b8ebe9b4ff0", // WhitelistPolicy
+]);
+
+type PeerPreparedTransaction = {
+  chainId: number;
+  to: string;
+  data: string;
+};
+
+/**
+ * Fail closed if the SDK prepares a transaction outside Peer Cash on Base.
+ * USDC is accepted only for an `approve(address,uint256)` whose spender is an
+ * allowlisted Peer Cash contract.
+ *
+ * @param txs - Transactions returned by a Peer Cash prepare method.
+ * @throws If a chain, target, selector, or approve spender is unexpected.
+ */
+export function assertPeerTargets(txs: readonly PeerPreparedTransaction[]): void {
+  for (const tx of txs) {
+    if (tx.chainId !== BASE_CHAIN_ID) {
+      throw new Error(`Peer Cash prepared unexpected chain ${tx.chainId}`);
+    }
+
+    const target = tx.to.toLowerCase();
+    if (PEER_CASH_BASE_TARGETS.has(target)) continue;
+
+    if (target === BASE_USDC_ADDRESS) {
+      const data = tx.data.toLowerCase();
+      if (
+        !/^0x[0-9a-f]+$/.test(data) ||
+        !data.startsWith(ERC20_APPROVE_SELECTOR) ||
+        data.length < 138 ||
+        data.slice(10, 34) !== "0".repeat(24)
+      ) {
+        throw new Error("Peer Cash prepared unexpected Base USDC call");
+      }
+      const spender = `0x${data.slice(34, 74)}`;
+      if (PEER_CASH_BASE_TARGETS.has(spender)) continue;
+      throw new Error(`Peer Cash prepared USDC approval for unexpected spender ${spender}`);
+    }
+
+    throw new Error(`Peer Cash prepared unexpected target ${tx.to}`);
+  }
+}
+
 let client: CashClient | undefined;
 
 /**

--- a/agentkit-core/src/actions/PeerCashAction/estimate.ts
+++ b/agentkit-core/src/actions/PeerCashAction/estimate.ts
@@ -1,0 +1,74 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { type CurrencyType, estimateToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+
+const PEER_CASH_ESTIMATE_PROMPT = `
+Estimates the fiat a Base USDC cash-out receives at the live Chainlink oracle
+rate, with a recent-fill ETA for the chosen platform and currency.
+
+USAGE
+  name : peer_cash_estimate
+  args :
+    • amount (string, required) - decimal USDC, e.g. "250" or "12.34"
+    • currency (string, required) - ISO 4217 code from peer_cash_capabilities
+    • platform (string, optional) - payout platform, for pair-specific fill timing
+
+IMPORTANT
+  • This is not a locked quote. Peer Cash charges no spread and the binding rate
+    resolves when a buyer fills the order, so the fiat can move between the
+    estimate and the fill.
+  • The eta is a rolling 30-day median of how long similar orders waited for
+    their first fill. It is evidence, not a guarantee.
+
+Use peer_cash_prepare_cashout next to build the transactions that open the order.
+`;
+
+export const PeerCashEstimateInput = z
+  .object({
+    amount: z.string().describe("The Base USDC amount to estimate, as a decimal string"),
+    currency: z.string().describe("The ISO 4217 fiat currency code to receive, e.g. USD"),
+    platform: z
+      .string()
+      .optional()
+      .nullable()
+      .describe("Optional payout platform id, for pair-specific fill timing"),
+  })
+  .strip()
+  .describe("Instructions for estimating a Peer Cash cash-out");
+
+/**
+ * Estimates the fiat received for a Base USDC cash-out.
+ *
+ * @param _wallet - Unused; estimating never touches the wallet.
+ * @param args - The amount, currency, and optional payout platform.
+ * @returns The oracle estimate as JSON, or a typed error message.
+ */
+export async function peerCashEstimate(
+  _wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashEstimateInput>,
+): Promise<string> {
+  try {
+    const estimate = await getPeerCashClient().estimate({
+      amount: toUsdcBaseUnits(args.amount),
+      currency: args.currency.trim().toUpperCase() as CurrencyType,
+      ...(args.platform ? { platform: args.platform } : {}),
+    });
+    return formatResult(estimateToJson(estimate));
+  } catch (error) {
+    return formatError("estimate", error);
+  }
+}
+
+/**
+ * Peer Cash estimate action.
+ */
+export class PeerCashEstimateAction implements AgentkitAction<typeof PeerCashEstimateInput> {
+  public name = "peer_cash_estimate";
+  public description = PEER_CASH_ESTIMATE_PROMPT;
+  public argsSchema = PeerCashEstimateInput;
+  public func = peerCashEstimate;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/index.ts
+++ b/agentkit-core/src/actions/PeerCashAction/index.ts
@@ -1,0 +1,35 @@
+import { PeerCashCapabilitiesAction } from "./capabilities";
+import { PeerCashEstimateAction } from "./estimate";
+import { PeerCashOrderAction } from "./order";
+import { PeerCashOrdersAction } from "./orders";
+import { PeerCashPrepareAccessPolicyAction } from "./prepareAccessPolicy";
+import { PeerCashPrepareCashoutAction } from "./prepareCashout";
+import { PeerCashPrepareTopUpAction } from "./prepareTopUp";
+import { PeerCashPrepareWithdrawAction } from "./prepareWithdraw";
+
+export { PeerCashCapabilitiesAction } from "./capabilities";
+export { PeerCashEstimateAction } from "./estimate";
+export { PeerCashOrderAction } from "./order";
+export { PeerCashOrdersAction } from "./orders";
+export { PeerCashPrepareAccessPolicyAction } from "./prepareAccessPolicy";
+export { PeerCashPrepareCashoutAction } from "./prepareCashout";
+export { PeerCashPrepareTopUpAction } from "./prepareTopUp";
+export { PeerCashPrepareWithdrawAction } from "./prepareWithdraw";
+
+/**
+ * Peer Cash — Base USDC to fiat, non-custodial.
+ *
+ * Reads need no credential and every mutating verb returns unsigned
+ * transactions, so the agent submits them through send_transaction and Peer
+ * never sees a key.
+ */
+export const PEER_CASH_ACTIONS = [
+  new PeerCashCapabilitiesAction(),
+  new PeerCashEstimateAction(),
+  new PeerCashPrepareCashoutAction(),
+  new PeerCashPrepareAccessPolicyAction(),
+  new PeerCashOrderAction(),
+  new PeerCashOrdersAction(),
+  new PeerCashPrepareTopUpAction(),
+  new PeerCashPrepareWithdrawAction(),
+];

--- a/agentkit-core/src/actions/PeerCashAction/order.ts
+++ b/agentkit-core/src/actions/PeerCashAction/order.ts
@@ -1,0 +1,63 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { orderToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient } from "./client";
+
+const PEER_CASH_ORDER_PROMPT = `
+Reads the current state of one Peer Cash order.
+
+USAGE
+  name : peer_cash_order
+  args :
+    • depositId (string, required) - "escrowAddress_onchainId", e.g.
+      "0x777777779d229cdf3110e9de47943791c26300ef_3936"
+
+RETURNS
+  - state: awaiting-buyer | matched | delivering | delivered | returned
+  - totalAmount, filledAmount, pendingAmount, returnedAmount in USDC base units
+  - fills: each buyer's locked rate, fiat owed, verified fiat paid, and latency
+  - nextActions: wait | withdraw
+
+An order is resumable from its id alone, so this works in a fresh session with
+no prior state. A brief ORDER_NOT_FOUND right after the deposit confirms is
+indexer lag: retry this read, never the transaction. Use peer_cash_orders to
+find the id.
+`;
+
+export const PeerCashOrderInput = z
+  .object({
+    depositId: z.string().describe("The composite Peer Cash order id, escrowAddress_onchainId"),
+  })
+  .strip()
+  .describe("Instructions for reading one Peer Cash order");
+
+/**
+ * Reads one Peer Cash order by its composite deposit id.
+ *
+ * @param _wallet - Unused; reading an order never touches the wallet.
+ * @param args - The composite deposit id.
+ * @returns The order state as JSON, or a typed error message.
+ */
+export async function peerCashOrder(
+  _wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashOrderInput>,
+): Promise<string> {
+  try {
+    return formatResult(orderToJson(await getPeerCashClient().order(args.depositId.trim())));
+  } catch (error) {
+    return formatError("order", error);
+  }
+}
+
+/**
+ * Peer Cash order-read action.
+ */
+export class PeerCashOrderAction implements AgentkitAction<typeof PeerCashOrderInput> {
+  public name = "peer_cash_order";
+  public description = PEER_CASH_ORDER_PROMPT;
+  public argsSchema = PeerCashOrderInput;
+  public func = peerCashOrder;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/orders.ts
+++ b/agentkit-core/src/actions/PeerCashAction/orders.ts
@@ -1,0 +1,77 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { orderToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient } from "./client";
+
+const PEER_CASH_ORDERS_PROMPT = `
+Lists the Peer Cash orders belonging to a maker address, newest first.
+
+USAGE
+  name : peer_cash_orders
+  args :
+    • address (string, optional) - the maker wallet. Defaults to this agent's
+      smart account when one is configured.
+    • inFlight (boolean, optional) - only orders still needing attention
+      (awaiting-buyer, matched, delivering). Defaults to false.
+    • limit (number, optional) - maximum deposits to scan, 1 to 1000. Default 100.
+
+A Peer Cash order is an on-chain deposit keyed by its depositor, so this reads
+straight from the chain with no account linkage. Use peer_cash_order for the
+full detail of a single order.
+`;
+
+export const PeerCashOrdersInput = z
+  .object({
+    address: z
+      .string()
+      .optional()
+      .nullable()
+      .describe("The maker wallet address; defaults to this agent's smart account"),
+    inFlight: z
+      .boolean()
+      .optional()
+      .nullable()
+      .describe("Only return orders still awaiting a buyer, matched, or delivering"),
+    limit: z.number().optional().nullable().describe("Maximum deposits to scan (default 100)"),
+  })
+  .strip()
+  .describe("Instructions for listing Peer Cash orders");
+
+/**
+ * Lists the Peer Cash orders owned by a maker address.
+ *
+ * @param wallet - Used only to default the address; may be undefined.
+ * @param args - The optional address, in-flight filter, and scan limit.
+ * @returns The orders as JSON, or a typed error message.
+ */
+export async function peerCashOrders(
+  wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashOrdersInput>,
+): Promise<string> {
+  try {
+    const owner = args.address?.trim() || (await wallet?.getAddress());
+    if (!owner) {
+      return "Error: peer_cash_orders needs an address. Pass one, or configure Agentkit with a wallet so the agent's own smart account can be used.";
+    }
+    const orders = await getPeerCashClient().orders(owner, {
+      ...(args.inFlight != null ? { inFlight: args.inFlight } : {}),
+      ...(args.limit != null ? { limit: args.limit } : {}),
+    });
+    return formatResult(orders.map(orderToJson));
+  } catch (error) {
+    return formatError("orders", error);
+  }
+}
+
+/**
+ * Peer Cash order-listing action.
+ */
+export class PeerCashOrdersAction implements AgentkitAction<typeof PeerCashOrdersInput> {
+  public name = "peer_cash_orders";
+  public description = PEER_CASH_ORDERS_PROMPT;
+  public argsSchema = PeerCashOrdersInput;
+  public func = peerCashOrders;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/prepareAccessPolicy.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareAccessPolicy.ts
@@ -2,7 +2,7 @@ import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
 import { preparedTxToJson } from "@zkp2p/cash";
 import { z } from "zod";
 import type { AgentkitAction } from "../../agentkit";
-import { formatError, formatResult, getPeerCashClient } from "./client";
+import { assertPeerTargets, formatError, formatResult, getPeerCashClient } from "./client";
 
 const PEER_CASH_PREPARE_ACCESS_POLICY_PROMPT = `
 Builds the verified-buyer access-policy transaction a Venmo, Cash App, or PayPal
@@ -44,6 +44,7 @@ export async function peerCashPrepareAccessPolicy(
 ): Promise<string> {
   try {
     const tx = getPeerCashClient().prepareAccessPolicy(args.depositId.trim());
+    assertPeerTargets([tx]);
     return formatResult(preparedTxToJson(tx));
   } catch (error) {
     return formatError("prepare access policy", error);

--- a/agentkit-core/src/actions/PeerCashAction/prepareAccessPolicy.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareAccessPolicy.ts
@@ -1,0 +1,65 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { preparedTxToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient } from "./client";
+
+const PEER_CASH_PREPARE_ACCESS_POLICY_PROMPT = `
+Builds the verified-buyer access-policy transaction a Venmo, Cash App, or PayPal
+order needs before any buyer can fill it.
+
+USAGE
+  name : peer_cash_prepare_access_policy
+  args :
+    • depositId (string, required) - "escrowAddress_onchainId"
+
+WHEN TO USE
+  Only after peer_cash_prepare_cashout returned accessPolicyRequired: true and
+  its createDeposit transaction has confirmed, because the policy applies to the
+  order that deposit created. Orders on every other platform never need this.
+
+CUSTODY
+  This action returns one UNSIGNED transaction and never accepts or reads a
+  private key. Submit it with send_transaction from the maker address that owns
+  the order.
+`;
+
+export const PeerCashPrepareAccessPolicyInput = z
+  .object({
+    depositId: z.string().describe("The composite Peer Cash order id, escrowAddress_onchainId"),
+  })
+  .strip()
+  .describe("Instructions for preparing a Peer Cash order access policy");
+
+/**
+ * Prepares the unsigned access-policy transaction for a restricted order.
+ *
+ * @param _wallet - Unused; the prepare path never signs or reads the wallet.
+ * @param args - The order id.
+ * @returns The unsigned transaction as JSON, or a typed error message.
+ */
+export async function peerCashPrepareAccessPolicy(
+  _wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashPrepareAccessPolicyInput>,
+): Promise<string> {
+  try {
+    const tx = getPeerCashClient().prepareAccessPolicy(args.depositId.trim());
+    return formatResult(preparedTxToJson(tx));
+  } catch (error) {
+    return formatError("prepare access policy", error);
+  }
+}
+
+/**
+ * Peer Cash prepare-access-policy action.
+ */
+export class PeerCashPrepareAccessPolicyAction
+  implements AgentkitAction<typeof PeerCashPrepareAccessPolicyInput>
+{
+  public name = "peer_cash_prepare_access_policy";
+  public description = PEER_CASH_PREPARE_ACCESS_POLICY_PROMPT;
+  public argsSchema = PeerCashPrepareAccessPolicyInput;
+  public func = peerCashPrepareAccessPolicy;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/prepareCashout.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareCashout.ts
@@ -2,7 +2,13 @@ import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
 import { type CurrencyType, prepareResultToJson } from "@zkp2p/cash";
 import { z } from "zod";
 import type { AgentkitAction } from "../../agentkit";
-import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+import {
+  assertPeerTargets,
+  formatError,
+  formatResult,
+  getPeerCashClient,
+  toUsdcBaseUnits,
+} from "./client";
 
 const PEER_CASH_PREPARE_CASHOUT_PROMPT = `
 Builds the transactions that open a Peer Cash order, turning Base USDC into fiat
@@ -65,6 +71,7 @@ export async function peerCashPrepareCashout(
         payee: args.payee.trim(),
       },
     });
+    assertPeerTargets(plan.txs);
     return formatResult(prepareResultToJson(plan));
   } catch (error) {
     return formatError("prepare cashout", error);

--- a/agentkit-core/src/actions/PeerCashAction/prepareCashout.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareCashout.ts
@@ -1,0 +1,86 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { type CurrencyType, prepareResultToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+
+const PEER_CASH_PREPARE_CASHOUT_PROMPT = `
+Builds the transactions that open a Peer Cash order, turning Base USDC into fiat
+paid by a buyer at the live Chainlink oracle rate.
+
+USAGE
+  name : peer_cash_prepare_cashout
+  args :
+    • amount (string, required) - decimal USDC, e.g. "250" or "12.34"
+    • platform (string, required) - payout platform id from peer_cash_capabilities
+    • currency (string, required) - ISO 4217 code the platform supports
+    • payee (string, required) - your handle on that platform, e.g. "@andrew-w"
+      for Venmo. peer_cash_capabilities gives the exact format per platform.
+
+CUSTODY
+  This action returns UNSIGNED transactions and never accepts or reads a private
+  key. Submit each entry of txs with send_transaction, in the given order, and
+  confirm each with get_transaction_status before submitting the next. The order
+  belongs to whichever address submits them, and every transaction targets Base
+  (chain 8453), so the agent must be configured on Base.
+
+RETURNS
+  - txs: ordered [approve, createDeposit] as { to, data, value, chainId }
+  - steps: a human label for each transaction, at the same index
+  - accessPolicyRequired: when true the platform is Venmo, Cash App, or PayPal
+    and peer_cash_prepare_access_policy MUST be run once createDeposit confirms,
+    otherwise no buyer can fill the order
+
+Peer validates the payee handle with the platform before returning anything, so
+a handle that does not resolve fails here rather than after funds are committed.
+`;
+
+export const PeerCashPrepareCashoutInput = z
+  .object({
+    amount: z.string().describe("The Base USDC amount to cash out, as a decimal string"),
+    platform: z.string().describe("The payout platform id, e.g. venmo"),
+    currency: z.string().describe("The ISO 4217 fiat currency code to receive, e.g. USD"),
+    payee: z.string().describe("Your payee handle on the selected platform"),
+  })
+  .strip()
+  .describe("Instructions for preparing a Peer Cash cash-out");
+
+/**
+ * Prepares the unsigned transactions that open a Peer Cash order.
+ *
+ * @param _wallet - Unused; the prepare path never signs or reads the wallet.
+ * @param args - The amount, platform, currency, and payee handle.
+ * @returns The unsigned plan as JSON, or a typed error message.
+ */
+export async function peerCashPrepareCashout(
+  _wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashPrepareCashoutInput>,
+): Promise<string> {
+  try {
+    const plan = await getPeerCashClient().prepare({
+      amount: toUsdcBaseUnits(args.amount),
+      receive: {
+        platform: args.platform.trim(),
+        currency: args.currency.trim().toUpperCase() as CurrencyType,
+        payee: args.payee.trim(),
+      },
+    });
+    return formatResult(prepareResultToJson(plan));
+  } catch (error) {
+    return formatError("prepare cashout", error);
+  }
+}
+
+/**
+ * Peer Cash prepare-cashout action.
+ */
+export class PeerCashPrepareCashoutAction
+  implements AgentkitAction<typeof PeerCashPrepareCashoutInput>
+{
+  public name = "peer_cash_prepare_cashout";
+  public description = PEER_CASH_PREPARE_CASHOUT_PROMPT;
+  public argsSchema = PeerCashPrepareCashoutInput;
+  public func = peerCashPrepareCashout;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/prepareTopUp.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareTopUp.ts
@@ -1,0 +1,72 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { preparedStepToJson, preparedTxToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+
+const PEER_CASH_PREPARE_TOP_UP_PROMPT = `
+Builds the transactions that add more Base USDC to a live Peer Cash order,
+keeping the same payee and the same live oracle rate.
+
+USAGE
+  name : peer_cash_prepare_topup
+  args :
+    • depositId (string, required) - "escrowAddress_onchainId"
+    • amount (string, required) - decimal USDC to add, e.g. "250"
+
+CUSTODY
+  This action returns UNSIGNED transactions and never accepts or reads a private
+  key. Submit each entry of txs with send_transaction, in the given order
+  ([approve, addFunds]), from the maker address that owns the order.
+
+Topping up an order that has already delivered or been returned fails with
+ORDER_NOT_ACTIVE; check peer_cash_order first, or open a new order with
+peer_cash_prepare_cashout instead.
+`;
+
+export const PeerCashPrepareTopUpInput = z
+  .object({
+    depositId: z.string().describe("The composite Peer Cash order id, escrowAddress_onchainId"),
+    amount: z.string().describe("The additional Base USDC to add, as a decimal string"),
+  })
+  .strip()
+  .describe("Instructions for preparing a Peer Cash top-up");
+
+/**
+ * Prepares the unsigned transactions that add USDC to a live Peer Cash order.
+ *
+ * @param _wallet - Unused; the prepare path never signs or reads the wallet.
+ * @param args - The order id and the amount to add.
+ * @returns The unsigned plan as JSON, or a typed error message.
+ */
+export async function peerCashPrepareTopUp(
+  _wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashPrepareTopUpInput>,
+): Promise<string> {
+  try {
+    const { txs, steps } = await getPeerCashClient().prepareTopUp(
+      args.depositId.trim(),
+      toUsdcBaseUnits(args.amount),
+    );
+    return formatResult({
+      txs: txs.map(preparedTxToJson),
+      steps: steps.map(preparedStepToJson),
+    });
+  } catch (error) {
+    return formatError("prepare top-up", error);
+  }
+}
+
+/**
+ * Peer Cash prepare-top-up action.
+ */
+export class PeerCashPrepareTopUpAction
+  implements AgentkitAction<typeof PeerCashPrepareTopUpInput>
+{
+  public name = "peer_cash_prepare_topup";
+  public description = PEER_CASH_PREPARE_TOP_UP_PROMPT;
+  public argsSchema = PeerCashPrepareTopUpInput;
+  public func = peerCashPrepareTopUp;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/PeerCashAction/prepareTopUp.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareTopUp.ts
@@ -2,7 +2,13 @@ import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
 import { preparedStepToJson, preparedTxToJson } from "@zkp2p/cash";
 import { z } from "zod";
 import type { AgentkitAction } from "../../agentkit";
-import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+import {
+  assertPeerTargets,
+  formatError,
+  formatResult,
+  getPeerCashClient,
+  toUsdcBaseUnits,
+} from "./client";
 
 const PEER_CASH_PREPARE_TOP_UP_PROMPT = `
 Builds the transactions that add more Base USDC to a live Peer Cash order,
@@ -48,6 +54,7 @@ export async function peerCashPrepareTopUp(
       args.depositId.trim(),
       toUsdcBaseUnits(args.amount),
     );
+    assertPeerTargets(txs);
     return formatResult({
       txs: txs.map(preparedTxToJson),
       steps: steps.map(preparedStepToJson),

--- a/agentkit-core/src/actions/PeerCashAction/prepareWithdraw.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareWithdraw.ts
@@ -2,7 +2,13 @@ import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
 import { preparedStepToJson, preparedTxToJson } from "@zkp2p/cash";
 import { z } from "zod";
 import type { AgentkitAction } from "../../agentkit";
-import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+import {
+  assertPeerTargets,
+  formatError,
+  formatResult,
+  getPeerCashClient,
+  toUsdcBaseUnits,
+} from "./client";
 
 const PEER_CASH_PREPARE_WITHDRAW_PROMPT = `
 Builds the transactions that pull USDC back out of a Peer Cash order.
@@ -59,6 +65,7 @@ export async function peerCashPrepareWithdraw(
       args.depositId.trim(),
       args.amount ? { amount: toUsdcBaseUnits(args.amount) } : undefined,
     );
+    assertPeerTargets(txs);
     return formatResult({
       txs: txs.map(preparedTxToJson),
       steps: steps.map(preparedStepToJson),

--- a/agentkit-core/src/actions/PeerCashAction/prepareWithdraw.ts
+++ b/agentkit-core/src/actions/PeerCashAction/prepareWithdraw.ts
@@ -1,0 +1,83 @@
+import type { ZeroXgaslessSmartAccount } from "@0xgasless/smart-account-sdk";
+import { preparedStepToJson, preparedTxToJson } from "@zkp2p/cash";
+import { z } from "zod";
+import type { AgentkitAction } from "../../agentkit";
+import { formatError, formatResult, getPeerCashClient, toUsdcBaseUnits } from "./client";
+
+const PEER_CASH_PREPARE_WITHDRAW_PROMPT = `
+Builds the transactions that pull USDC back out of a Peer Cash order.
+
+USAGE
+  name : peer_cash_prepare_withdraw
+  args :
+    • depositId (string, required) - "escrowAddress_onchainId"
+    • amount (string, optional) - decimal USDC to withdraw. Omit to close the
+      order and take back everything still unlocked.
+
+CUSTODY
+  This action returns UNSIGNED transactions and never accepts or reads a private
+  key. Submit each entry of txs with send_transaction, in the given order, from
+  the maker address that owns the order.
+
+BEHAVIOUR
+  • Without amount the order is closed, and the plan includes a
+    pruneExpiredIntents transaction first when expired buyer intents are in the
+    way.
+  • A live buyer intent locks the matched funds and fails a full close with
+    ACTIVE_INTENT_BLOCKS_WITHDRAWAL until it expires; that error is retryable.
+  • With amount it is a partial withdrawal of the unlocked balance, which a live
+    buyer intent does not block.
+
+Use peer_cash_order first to check that withdraw is in nextActions.
+`;
+
+export const PeerCashPrepareWithdrawInput = z
+  .object({
+    depositId: z.string().describe("The composite Peer Cash order id, escrowAddress_onchainId"),
+    amount: z
+      .string()
+      .optional()
+      .nullable()
+      .describe("Decimal USDC to withdraw; omit to close the order entirely"),
+  })
+  .strip()
+  .describe("Instructions for preparing a Peer Cash withdrawal");
+
+/**
+ * Prepares the unsigned transactions that unwind a Peer Cash order.
+ *
+ * @param _wallet - Unused; the prepare path never signs or reads the wallet.
+ * @param args - The order id and an optional partial amount.
+ * @returns The unsigned plan as JSON, or a typed error message.
+ */
+export async function peerCashPrepareWithdraw(
+  _wallet: ZeroXgaslessSmartAccount,
+  args: z.infer<typeof PeerCashPrepareWithdrawInput>,
+): Promise<string> {
+  try {
+    const { txs, steps } = await getPeerCashClient().prepareWithdraw(
+      args.depositId.trim(),
+      args.amount ? { amount: toUsdcBaseUnits(args.amount) } : undefined,
+    );
+    return formatResult({
+      txs: txs.map(preparedTxToJson),
+      steps: steps.map(preparedStepToJson),
+    });
+  } catch (error) {
+    return formatError("prepare withdraw", error);
+  }
+}
+
+/**
+ * Peer Cash prepare-withdraw action.
+ */
+export class PeerCashPrepareWithdrawAction
+  implements AgentkitAction<typeof PeerCashPrepareWithdrawInput>
+{
+  public name = "peer_cash_prepare_withdraw";
+  public description = PEER_CASH_PREPARE_WITHDRAW_PROMPT;
+  public argsSchema = PeerCashPrepareWithdrawInput;
+  public func = peerCashPrepareWithdraw;
+  public walletOptional = true;
+  public smartAccountRequired = false;
+}

--- a/agentkit-core/src/actions/index.ts
+++ b/agentkit-core/src/actions/index.ts
@@ -26,6 +26,8 @@ import { CalculateTopicHashAction } from "./CalculateTopicHashAction/calculateTo
 import { RunTerminalCommandAction } from "./RunTerminalCommandAction/runTerminalCommandAction";
 import { AuroraWhitelistAction } from "./aurora/auroraWhitelistAction";
 import { AuroraGasPolicyAction } from "./aurora/auroraGasPolicyAction";
+import { PEER_CASH_ACTIONS } from "./PeerCashAction";
+export * from "./PeerCashAction";
 import { PLATFORM_ACTIONS } from "./platform";
 export * from "./platform";
 import { TOOL_GATEWAY_ACTIONS } from "./tools";
@@ -78,6 +80,8 @@ export function getAllAgentkitActions(): AgentkitAction<ActionSchemaAny>[] {
     ...TOOL_GATEWAY_ACTIONS,
     // Trust layer — ERC-8004 identity, reputation, feedback
     ...TRUST_ACTIONS,
+    // Peer Cash — Base USDC to fiat, unsigned plans signed by send_transaction
+    ...PEER_CASH_ACTIONS,
     // Guarded generic HTTP (safe replacement for curl-via-terminal)
     new HttpRequestAction(),
     // TODO: DataHaven temporarily disabled due to ESM compatibility issue

--- a/agentkit-core/test/peer-cash.smoke.mjs
+++ b/agentkit-core/test/peer-cash.smoke.mjs
@@ -11,6 +11,14 @@
 import assert from "node:assert/strict";
 
 const { Agentkit, getAllAgentkitActions } = await import("../dist/index.js");
+const { assertPeerTargets } = await import("../dist/actions/PeerCashAction/client.js");
+
+const BASE_USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+const PEER_ESCROW = "0x777777779d229cdF3110e9de47943791c26300Ef";
+const PEER_POLICY = "0xBC53641b4B2504f0061D6a9426C61B8eBE9B4Ff0";
+const APPROVE_SELECTOR = "095ea7b3";
+const approve = spender =>
+  `0x${APPROVE_SELECTOR}${spender.slice(2).toLowerCase().padStart(64, "0")}${"1".padStart(64, "0")}`;
 
 const ACTIONS = [
   "peer_cash_capabilities",
@@ -40,22 +48,73 @@ for (const name of ACTIONS) {
 // Every prepare verb must tell the agent it returns unsigned transactions.
 for (const name of ACTIONS.filter(n => n.includes("prepare"))) {
   assert.match(byName(name).description, /UNSIGNED/, `${name} must state that it does not sign`);
-  assert.match(byName(name).description, /send_transaction/, `${name} must name the signing action`);
+  assert.match(
+    byName(name).description,
+    /send_transaction/,
+    `${name} must name the signing action`,
+  );
 }
 
 // ── argument schemas ──
 
-assert.deepEqual(byName("peer_cash_estimate").argsSchema.parse({ amount: "250", currency: "EUR" }), {
-  amount: "250",
-  currency: "EUR",
-});
-assert.throws(() => byName("peer_cash_estimate").argsSchema.parse({ amount: 250, currency: "EUR" }));
+assert.deepEqual(
+  byName("peer_cash_estimate").argsSchema.parse({ amount: "250", currency: "EUR" }),
+  {
+    amount: "250",
+    currency: "EUR",
+  },
+);
+assert.throws(() =>
+  byName("peer_cash_estimate").argsSchema.parse({ amount: 250, currency: "EUR" }),
+);
 assert.throws(() => byName("peer_cash_order").argsSchema.parse({}));
 assert.deepEqual(byName("peer_cash_orders").argsSchema.parse({}), {});
 
 // ── typed errors, without a wallet and without the network ──
 
 const bare = new Agentkit();
+
+// ── prepared transaction target allowlist ──
+
+assert.doesNotThrow(() =>
+  assertPeerTargets([
+    { chainId: 8453, to: BASE_USDC, data: approve(PEER_ESCROW) },
+    { chainId: 8453, to: PEER_ESCROW, data: "0x12345678" },
+    { chainId: 8453, to: PEER_POLICY, data: "0x12345678" },
+  ]),
+);
+assert.throws(
+  () => assertPeerTargets([{ chainId: 1, to: PEER_ESCROW, data: "0x12345678" }]),
+  /unexpected chain/,
+);
+assert.throws(
+  () =>
+    assertPeerTargets([
+      { chainId: 8453, to: "0x1111111111111111111111111111111111111111", data: "0x12345678" },
+    ]),
+  /unexpected target/,
+);
+assert.throws(
+  () =>
+    assertPeerTargets([
+      {
+        chainId: 8453,
+        to: BASE_USDC,
+        data: approve("0x1111111111111111111111111111111111111111"),
+      },
+    ]),
+  /unexpected spender/,
+);
+for (const data of [
+  "0xdeadbeef",
+  approve(PEER_ESCROW).replace(APPROVE_SELECTOR, "deadbeef"),
+  approve(PEER_ESCROW).replace(`${APPROVE_SELECTOR}000000`, `${APPROVE_SELECTOR}100000`),
+]) {
+  assert.throws(
+    () => assertPeerTargets([{ chainId: 8453, to: BASE_USDC, data }]),
+    /unexpected Base USDC call/,
+  );
+}
 
 const badAmount = await bare.run(byName("peer_cash_estimate"), {
   amount: "12.3456789",

--- a/agentkit-core/test/peer-cash.smoke.mjs
+++ b/agentkit-core/test/peer-cash.smoke.mjs
@@ -1,0 +1,128 @@
+/**
+ * Peer Cash smoke test — runs against dist/.
+ *
+ * Offline by default: registration, wallet-optional dispatch, argument schemas,
+ * and the typed error surface, none of which touch the network.
+ *
+ * Set PEER_CASH_SMOKE_LIVE=1 to also read Peer production (capabilities,
+ * estimate, order, orders) and build an unsigned cash-out plan. Nothing is ever
+ * signed or broadcast: the prepare path returns transactions and stops.
+ */
+import assert from "node:assert/strict";
+
+const { Agentkit, getAllAgentkitActions } = await import("../dist/index.js");
+
+const ACTIONS = [
+  "peer_cash_capabilities",
+  "peer_cash_estimate",
+  "peer_cash_prepare_cashout",
+  "peer_cash_prepare_access_policy",
+  "peer_cash_order",
+  "peer_cash_orders",
+  "peer_cash_prepare_topup",
+  "peer_cash_prepare_withdraw",
+];
+
+const actions = getAllAgentkitActions();
+const byName = n => actions.find(a => a.name === n);
+
+// ── registration ──
+
+for (const name of ACTIONS) {
+  const action = byName(name);
+  assert.ok(action, `missing ${name}`);
+  assert.equal(action.walletOptional, true, `${name} should be walletOptional`);
+  assert.equal(action.smartAccountRequired, false, `${name} should not require a smart account`);
+  assert.ok(action.description.length > 200, `${name} needs a description an LLM can act on`);
+  assert.ok(action.argsSchema, `${name} needs an argsSchema`);
+}
+
+// Every prepare verb must tell the agent it returns unsigned transactions.
+for (const name of ACTIONS.filter(n => n.includes("prepare"))) {
+  assert.match(byName(name).description, /UNSIGNED/, `${name} must state that it does not sign`);
+  assert.match(byName(name).description, /send_transaction/, `${name} must name the signing action`);
+}
+
+// ── argument schemas ──
+
+assert.deepEqual(byName("peer_cash_estimate").argsSchema.parse({ amount: "250", currency: "EUR" }), {
+  amount: "250",
+  currency: "EUR",
+});
+assert.throws(() => byName("peer_cash_estimate").argsSchema.parse({ amount: 250, currency: "EUR" }));
+assert.throws(() => byName("peer_cash_order").argsSchema.parse({}));
+assert.deepEqual(byName("peer_cash_orders").argsSchema.parse({}), {});
+
+// ── typed errors, without a wallet and without the network ──
+
+const bare = new Agentkit();
+
+const badAmount = await bare.run(byName("peer_cash_estimate"), {
+  amount: "12.3456789",
+  currency: "USD",
+});
+assert.match(badAmount, /^Error: Peer Cash estimate failed\./);
+assert.match(badAmount, /decimals/);
+
+const noAddress = await bare.run(byName("peer_cash_orders"), {});
+assert.match(noAddress, /needs an address/);
+
+// ── live reads (opt in) ──
+
+if (process.env.PEER_CASH_SMOKE_LIVE === "1") {
+  const capabilities = JSON.parse(await bare.run(byName("peer_cash_capabilities"), {}));
+  assert.equal(capabilities.chainId, 8453);
+  assert.equal(capabilities.token.symbol, "USDC");
+  assert.equal(capabilities.pricing.spreadBps, 0);
+  assert.ok(capabilities.platforms.length > 0, "expected at least one payout platform");
+
+  const platform = capabilities.platforms.find(p => p.currencies.includes("USD"));
+  assert.ok(platform, "expected a platform paying USD");
+
+  const estimate = JSON.parse(
+    await bare.run(byName("peer_cash_estimate"), {
+      amount: "100",
+      currency: "USD",
+      platform: platform.platform,
+    }),
+  );
+  assert.equal(estimate.currency, "USD");
+  assert.equal(estimate.amount, "100000000");
+  assert.ok(estimate.receiveAmount > 0, "expected a positive fiat estimate");
+
+  const plan = JSON.parse(
+    await bare.run(byName("peer_cash_prepare_cashout"), {
+      amount: "25",
+      platform: "zelle",
+      currency: "USD",
+      payee: process.env.PEER_CASH_SMOKE_PAYEE ?? "richard2015@gmail.com",
+    }),
+  );
+  assert.equal(plan.txs.length, plan.steps.length);
+  assert.equal(plan.steps[0].kind, "approve");
+  assert.equal(plan.steps[1].kind, "createDeposit");
+  for (const tx of plan.txs) {
+    assert.equal(tx.chainId, 8453);
+    assert.match(tx.to, /^0x[0-9a-fA-F]{40}$/);
+    assert.match(tx.data, /^0x[0-9a-fA-F]+$/);
+  }
+  assert.equal(plan.accessPolicyRequired, false, "zelle needs no access policy");
+
+  const depositId = process.env.PEER_CASH_SMOKE_ORDER_ID;
+  if (depositId) {
+    const order = JSON.parse(await bare.run(byName("peer_cash_order"), { depositId }));
+    assert.equal(order.depositId, depositId);
+    assert.ok(
+      ["awaiting-buyer", "matched", "delivering", "delivered", "returned"].includes(order.state),
+      `unexpected order state ${order.state}`,
+    );
+
+    const owner = depositId.split("_")[0];
+    const orders = JSON.parse(await bare.run(byName("peer_cash_orders"), { address: owner }));
+    assert.ok(Array.isArray(orders), "peer_cash_orders should return an array");
+  }
+}
+
+console.log(
+  `PEER CASH SMOKE: all assertions passed${process.env.PEER_CASH_SMOKE_LIVE === "1" ? " (including live production reads)" : " (offline)"}`,
+);

--- a/agentkit-core/tsconfig.json
+++ b/agentkit-core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es2022",
     "outDir": "./dist",
     "rootDir": "./src",
     "paths": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,18 +17,17 @@
     },
     "agentkit-core": {
       "name": "@0xgasless/agentkit",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
-        "@0xgasless/agent": "^2.2.0",
+        "@0xgasless/agent": "^2.2.1",
         "@0xgasless/smart-account-sdk": "^0.0.15",
         "@langchain/core": "^0.3.40",
         "@polkadot/api": "^16.5.4",
         "@storagehub-sdk/core": "^0.4.0",
         "@storagehub-sdk/msp-client": "^0.4.0",
         "@storagehub/api-augment": "^0.2.14",
+        "@zkp2p/cash": "^0.4.9",
         "axios": "^1.7.9",
-        "merkletreejs": "^0.4.1",
-        "sqlite3": "^5.1.7",
         "viem": "2",
         "zod": "^3.23.8",
       },
@@ -48,7 +47,7 @@
     },
   },
   "packages": {
-    "@0xgasless/agent": ["@0xgasless/agent@2.2.0", "", {}, "sha512-X7U7Ujiz0qfDIceyxAeckJtD3pahnhTke09C4ZPULRzhV3kkTZ7rAj1Ge9Pa2oHcyUja3mAvL5j67zCLzScd1w=="],
+    "@0xgasless/agent": ["@0xgasless/agent@2.2.1", "", {}, "sha512-UrXeVA68dxMy52DxoCSaO781rkw1WLGc0g7QK9HJflyxqha2VXYjIeHxA+lNpbWBhX40Q95F2qDzfu8sLQxP3g=="],
 
     "@0xgasless/agentkit": ["@0xgasless/agentkit@workspace:agentkit-core"],
 
@@ -204,8 +203,6 @@
 
     "@ethereumjs/util": ["@ethereumjs/util@8.1.0", "", { "dependencies": { "@ethereumjs/rlp": "^4.0.1", "ethereum-cryptography": "^2.0.0", "micro-ftch": "^0.3.1" } }, "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA=="],
 
-    "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
-
     "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@1.27.2", "", { "dependencies": { "@shikijs/engine-oniguruma": "^1.27.2", "@shikijs/types": "^1.27.2", "@shikijs/vscode-textmate": "^10.0.1" } }, "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og=="],
 
     "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
@@ -264,9 +261,29 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@npmcli/fs": ["@npmcli/fs@1.1.1", "", { "dependencies": { "@gar/promisify": "^1.0.1", "semver": "^7.3.5" } }, "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ=="],
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "@peculiar/asn1-x509-attr": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-VKQz6sJYgSxtGaK6UdnNBUx7hmSdg0K331qrEWh5qxpQsyZGWBjxbq05AJ2bTWWjd7d+nJIxFzwvsR5T7DWC/A=="],
 
-    "@npmcli/move-file": ["@npmcli/move-file@1.1.2", "", { "dependencies": { "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg=="],
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-SbxRzHiWnRdiDuiiji/RLsJxu2au4hmSZSKK7GQOgNr2BVvheAlFQST9qqzRchUcZ6wvcyRuPXIfYXVzLoZ/5g=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-vNspHtTd9h6e8c2lMW+B/VHEUD+HRFV0fj/Gvz7SaJbwiecA8dxd96UTFPYI1PR8k7qwjjW9AFEyI+LuyVi4Kw=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.9.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.9.0", "@peculiar/asn1-pkcs8": "^2.9.0", "@peculiar/asn1-rsa": "^2.9.0", "@peculiar/asn1-schema": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-A6bX+gZr69U38Pg1mWvPrM1eRba6L6kLR8iVG+bJtKj3qSv2rSNmlXLtej7ZOkEWt6xL6PiJD73uFEdQI3BXCg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-1JH4FliKQ3trkMD17X+bKGsph5TsiM+AiiqnVKr1wxA/GoUSDHiWG/zROzLAbDIA7eclBCjQsp8hrBEJk7LRUQ=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.9.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.9.0", "@peculiar/asn1-pfx": "^2.9.0", "@peculiar/asn1-pkcs8": "^2.9.0", "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "@peculiar/asn1-x509-attr": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-igArY6bpCI6tOPm2EU9QPrXuKq2s1iraLCTym4UlooYdzcRDIPCRUN9TAEcqZ5rZhA+HiPdFKTbDP9vneN/tsg=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-vOD7Q4UmQWhlMYuWJawS2sD+/JcPKJNtyQuFZx09r+KFhm5/HxfGak63y/m56cpBjmb5k6PeRlQf1fvLQAieUA=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.9.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-AKvPMOM7LfK0uFe1m7o7+veOa8xQGPqsqOrKi3QKgCElzwjGp39mbhr2g7mt/v/mXQHiIvJmDj5cJS173x8Q9Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b9Na83rhRFQBd5CuMmuEqokYhmyWUbG7mNZl/thGhBwLpCdiZ85TZ3WFhF7OVgOekC5uKhLk4C3HKtdiScCMdQ=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.9.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.9.0", "@peculiar/asn1-x509": "^2.9.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-f+u+EyGjfPvPzvr0+rlh/TFEO7LWt84mEwQynCUYr4F6urf/8s6+ESJ23qfSn1aamkZR6AuBNaC62iEsGvp0+w=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
     "@polkadot-api/json-rpc-provider": ["@polkadot-api/json-rpc-provider@0.0.1", "", {}, "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA=="],
 
@@ -344,6 +361,8 @@
 
     "@polkadot/x-ws": ["@polkadot/x-ws@14.0.1", "", { "dependencies": { "@polkadot/x-global": "14.0.1", "tslib": "^2.8.0", "ws": "^8.18.0" } }, "sha512-Q18hoSuOl7F4aENNGNt9XYxkrjwZlC6xye9OQrPDeHam1SrvflGv9mSZHyo+mwJs0z1PCz2STpPEN9PKfZvHng=="],
 
+    "@relayprotocol/relay-sdk": ["@relayprotocol/relay-sdk@7.0.2", "", { "dependencies": { "axios": "^1.6.5" }, "peerDependencies": { "viem": ">=2.26.0" } }, "sha512-3VLRNEERcxTJnTcO1YDGsxYC8XPpGVou0cr/o3yqm1wyVuxQaScjlL99nHH7ghob08b7oZtzjrMPDIfejoSttA=="],
+
     "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
@@ -381,8 +400,6 @@
     "@substrate/light-client-extension-helpers": ["@substrate/light-client-extension-helpers@1.0.0", "", { "dependencies": { "@polkadot-api/json-rpc-provider": "^0.0.1", "@polkadot-api/json-rpc-provider-proxy": "^0.1.0", "@polkadot-api/observable-client": "^0.3.0", "@polkadot-api/substrate-client": "^0.1.2", "@substrate/connect-extension-protocol": "^2.0.0", "@substrate/connect-known-chains": "^1.1.5", "rxjs": "^7.8.1" }, "peerDependencies": { "smoldot": "2.x" } }, "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg=="],
 
     "@substrate/ss58-registry": ["@substrate/ss58-registry@1.51.0", "", {}, "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ=="],
-
-    "@tootallnate/once": ["@tootallnate/once@1.1.2", "", {}, "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="],
 
     "@tsd/typescript": ["@tsd/typescript@5.4.5", "", {}, "sha512-saiCxzHRhUrRxQV2JhH580aQUZiKQUXI38FcAcikcfOomAil4G4lxT0RfrrKywoAYP/rqAdYXYmNRLppcd+hQQ=="],
 
@@ -436,17 +453,19 @@
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+    "@zkp2p/cash": ["@zkp2p/cash@0.4.9", "", { "dependencies": { "@relayprotocol/relay-sdk": "^7.0.1", "@zkp2p/sdk": "0.12.0", "zod": "^4.4.3" }, "peerDependencies": { "react": ">=18", "viem": ">=2.37.3 <3" }, "optionalPeers": ["react"] }, "sha512-8lAPVO3fEGPGM2hRszv9wV/IC6XuxOknjJy/ReY+GJdLDbckurjg+Zh5Uu5YDRXs7uf1oqh11uKdHFTNMWLpKQ=="],
+
+    "@zkp2p/contracts-v2": ["@zkp2p/contracts-v2@0.4.0", "", { "dependencies": { "abitype": "^1.0.0" }, "peerDependencies": { "ethers": "^5.0.0 || ^6.0.0" } }, "sha512-wE4IfjRSUVfOiAULoh6eVUj5vExSlcMY6+VsRLOhGq+1q06uy/aS2lMYjzqoDAXibMpYPTVhsuy1MEB2jKGKqw=="],
+
+    "@zkp2p/indexer-schema": ["@zkp2p/indexer-schema@0.20.0", "", {}, "sha512-EQsmFfp61hI0zzILYoh8aPzf+CGeduoiAQQ+FD27oIQBj5piKFqNQCfzhI14A7lBWtS69gXqjPuJJTo/BOaO3w=="],
+
+    "@zkp2p/sdk": ["@zkp2p/sdk@0.12.0", "", { "dependencies": { "@zkp2p/contracts-v2": "0.4.0", "@zkp2p/indexer-schema": "0.20.0", "@zkp2p/zkp2p-attestation": "2.0.0", "ethers": "^6.0.0", "ox": "^0.11.1" }, "peerDependencies": { "react": ">=16.8.0", "viem": "^2.37.3" }, "optionalPeers": ["react"] }, "sha512-7boAYdUV+R3G+1hFOp7lQLxX9NUDVXtfW3RsgBt4ijhg3BqO9RBgpMfeWfqoE7kRUVDo/xNZL39bhBbXK6NmIA=="],
+
+    "@zkp2p/zkp2p-attestation": ["@zkp2p/zkp2p-attestation@2.0.0", "", { "dependencies": { "@peculiar/x509": "^1.14.0", "ethers": "^6.13.4" }, "bin": { "zkp2p-attestation-verify": "dist/cli/verify.js" } }, "sha512-m+HWDYTEW109xSqh0NWJFoWR0ZIoxJqQRguQltfr6RSkALBJFWv5WWDQrcPN0TiqTN2KdLI7BYQTDluZfjq2MA=="],
 
     "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
-
-    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
-
-    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
-
-    "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -456,15 +475,13 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
-    "aproba": ["aproba@2.0.0", "", {}, "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="],
-
-    "are-we-there-yet": ["are-we-there-yet@3.0.1", "", { "dependencies": { "delegates": "^1.0.0", "readable-stream": "^3.6.0" } }, "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg=="],
-
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "arrify": ["arrify@1.0.1", "", {}, "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -490,10 +507,6 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
-
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
-
     "bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -506,13 +519,9 @@
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
-
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "buffer-reverse": ["buffer-reverse@1.0.1", "", {}, "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg=="],
-
-    "cacache": ["cacache@15.3.0", "", { "dependencies": { "@npmcli/fs": "^1.0.0", "@npmcli/move-file": "^1.0.1", "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "glob": "^7.1.4", "infer-owner": "^1.0.4", "lru-cache": "^6.0.0", "minipass": "^3.1.1", "minipass-collect": "^1.0.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.2", "mkdirp": "^1.0.3", "p-map": "^4.0.0", "promise-inflight": "^1.0.1", "rimraf": "^3.0.2", "ssri": "^8.0.1", "tar": "^6.0.2", "unique-filename": "^1.1.1" } }, "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -530,13 +539,9 @@
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
-    "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
-
     "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
-
-    "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -548,8 +553,6 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "color-support": ["color-support@1.1.3", "", { "bin": { "color-support": "bin.js" } }, "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="],
-
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
@@ -559,8 +562,6 @@
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "concurrently": ["concurrently@8.2.2", "", { "dependencies": { "chalk": "^4.1.2", "date-fns": "^2.30.0", "lodash": "^4.17.21", "rxjs": "^7.8.1", "shell-quote": "^1.8.1", "spawn-command": "0.0.2", "supports-color": "^8.1.1", "tree-kill": "^1.2.2", "yargs": "^17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg=="],
-
-    "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
 
     "console-table-printer": ["console-table-printer@2.14.3", "", { "dependencies": { "simple-wcswidth": "^1.0.1" } }, "sha512-X5OCFnjYlXzRuC8ac5hPA2QflRjJvNKJocMhlnqK/Ap7q3DHXr0NJ0TGzwmEKOiOdJrjsSwEd0m+a32JAYPrKQ=="],
 
@@ -582,19 +583,11 @@
 
     "decamelize-keys": ["decamelize-keys@1.1.1", "", { "dependencies": { "decamelize": "^1.1.0", "map-obj": "^1.0.0" } }, "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg=="],
 
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
     "dedent": ["dedent@1.6.0", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA=="],
-
-    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
-
-    "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
-
-    "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
@@ -612,15 +605,7 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
-
-    "end-of-stream": ["end-of-stream@1.4.4", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q=="],
-
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
-
-    "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
@@ -658,8 +643,6 @@
 
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
 
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
-
     "expect": ["expect@29.7.0", "", { "dependencies": { "@jest/expect-utils": "^29.7.0", "jest-get-type": "^29.6.3", "jest-matcher-utils": "^29.7.0", "jest-message-util": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -671,8 +654,6 @@
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
-
-    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
 
@@ -686,17 +667,11 @@
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
-    "fs-minipass": ["fs-minipass@2.1.0", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg=="],
-
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "gauge": ["gauge@4.0.4", "", { "dependencies": { "aproba": "^1.0.3 || ^2.0.0", "color-support": "^1.1.3", "console-control-strings": "^1.1.0", "has-unicode": "^2.0.1", "signal-exit": "^3.0.7", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wide-align": "^1.1.5" } }, "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -711,8 +686,6 @@
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "get-tsconfig": ["get-tsconfig@4.10.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ=="],
-
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -736,27 +709,13 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "has-unicode": ["has-unicode@2.0.1", "", {}, "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="],
-
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
-    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
-
-    "http-proxy-agent": ["http-proxy-agent@4.0.1", "", { "dependencies": { "@tootallnate/once": "1", "agent-base": "6", "debug": "4" } }, "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg=="],
-
-    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
-
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
-
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -766,15 +725,9 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
-    "infer-owner": ["infer-owner@1.0.4", "", {}, "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="],
-
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
-
-    "ip-address": ["ip-address@9.0.5", "", { "dependencies": { "jsbn": "1.1.0", "sprintf-js": "^1.1.3" } }, "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g=="],
 
     "irregular-plurals": ["irregular-plurals@3.5.0", "", {}, "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ=="],
 
@@ -793,8 +746,6 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hex-prefixed": ["is-hex-prefixed@1.0.0", "", {}, "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA=="],
-
-    "is-lambda": ["is-lambda@1.0.1", "", {}, "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
@@ -878,8 +829,6 @@
 
     "js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
 
-    "jsbn": ["jsbn@1.1.0", "", {}, "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="],
-
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
@@ -916,8 +865,6 @@
 
     "make-error": ["make-error@1.3.6", "", {}, "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="],
 
-    "make-fetch-happen": ["make-fetch-happen@9.1.0", "", { "dependencies": { "agentkeepalive": "^4.1.3", "cacache": "^15.2.0", "http-cache-semantics": "^4.1.0", "http-proxy-agent": "^4.0.1", "https-proxy-agent": "^5.0.0", "is-lambda": "^1.0.1", "lru-cache": "^6.0.0", "minipass": "^3.1.3", "minipass-collect": "^1.0.2", "minipass-fetch": "^1.3.2", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.2", "promise-retry": "^2.0.1", "socks-proxy-agent": "^6.0.0", "ssri": "^8.0.0" } }, "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg=="],
-
     "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
 
     "map-obj": ["map-obj@4.3.0", "", {}, "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="],
@@ -934,7 +881,7 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
-    "merkletreejs": ["merkletreejs@0.4.1", "", { "dependencies": { "buffer-reverse": "^1.0.1", "crypto-js": "^4.2.0", "treeify": "^1.1.0" } }, "sha512-W2VSHeGTdAnWtedee+pgGn7SHvncMdINnMeHAaXrfarSaMNLff/pm7RCr/QXYxN6XzJFgJZY+28ejO0lAosW4A=="],
+    "merkletreejs": ["merkletreejs@0.3.11", "", { "dependencies": { "bignumber.js": "^9.0.1", "buffer-reverse": "^1.0.1", "crypto-js": "^4.2.0", "treeify": "^1.1.0", "web3-utils": "^1.3.4" } }, "sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ=="],
 
     "micro-ftch": ["micro-ftch@0.3.1", "", {}, "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg=="],
 
@@ -946,8 +893,6 @@
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -955,24 +900,6 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minimist-options": ["minimist-options@4.1.0", "", { "dependencies": { "arrify": "^1.0.1", "is-plain-obj": "^1.1.0", "kind-of": "^6.0.3" } }, "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A=="],
-
-    "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
-
-    "minipass-collect": ["minipass-collect@1.0.2", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA=="],
-
-    "minipass-fetch": ["minipass-fetch@1.4.1", "", { "dependencies": { "minipass": "^3.1.0", "minipass-sized": "^1.0.3", "minizlib": "^2.0.0" }, "optionalDependencies": { "encoding": "^0.1.12" } }, "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw=="],
-
-    "minipass-flush": ["minipass-flush@1.0.5", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw=="],
-
-    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
-
-    "minipass-sized": ["minipass-sized@1.0.3", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g=="],
-
-    "minizlib": ["minizlib@2.1.2", "", { "dependencies": { "minipass": "^3.0.0", "yallist": "^4.0.0" } }, "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg=="],
-
-    "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
-
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mock-fs": ["mock-fs@5.5.0", "", {}, "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA=="],
 
@@ -984,31 +911,19 @@
 
     "mylas": ["mylas@2.1.13", "", {}, "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg=="],
 
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
-
-    "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "nock": ["nock@13.5.6", "", { "dependencies": { "debug": "^4.1.0", "json-stringify-safe": "^5.0.1", "propagate": "^2.0.0" } }, "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ=="],
 
-    "node-abi": ["node-abi@3.75.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg=="],
-
-    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
-
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "node-gyp": ["node-gyp@8.4.1", "", { "dependencies": { "env-paths": "^2.2.0", "glob": "^7.1.4", "graceful-fs": "^4.2.6", "make-fetch-happen": "^9.1.0", "nopt": "^5.0.0", "npmlog": "^6.0.0", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.2", "which": "^2.0.2" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w=="],
-
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
-
-    "nopt": ["nopt@5.0.0", "", { "dependencies": { "abbrev": "1" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ=="],
 
     "normalize-package-data": ["normalize-package-data@3.0.3", "", { "dependencies": { "hosted-git-info": "^4.0.1", "is-core-module": "^2.5.0", "semver": "^7.3.4", "validate-npm-package-license": "^3.0.1" } }, "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA=="],
 
@@ -1016,23 +931,19 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "npmlog": ["npmlog@6.0.2", "", { "dependencies": { "are-we-there-yet": "^3.0.0", "console-control-strings": "^1.1.0", "gauge": "^4.0.3", "set-blocking": "^2.0.0" } }, "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg=="],
-
     "number-to-bn": ["number-to-bn@1.7.0", "", { "dependencies": { "bn.js": "4.11.6", "strip-hex-prefix": "1.0.0" } }, "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "ox": ["ox@0.7.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-+k9fY9PRNuAMHRFIUbiK9Nt5seYHHzSQs9Bj+iMETcGtlpS7SmBzcGSVUQO3+nqGLEiNK4598pHNFlVRaZbRsg=="],
+    "ox": ["ox@0.14.33", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ=="],
 
     "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "p-map": ["p-map@4.0.0", "", { "dependencies": { "aggregate-error": "^3.0.0" } }, "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ=="],
 
     "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
 
@@ -1066,13 +977,7 @@
 
     "plur": ["plur@4.0.0", "", { "dependencies": { "irregular-plurals": "^3.2.0" } }, "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg=="],
 
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
-
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
-
-    "promise-inflight": ["promise-inflight@1.0.1", "", {}, "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="],
-
-    "promise-retry": ["promise-retry@2.0.1", "", { "dependencies": { "err-code": "^2.0.2", "retry": "^0.12.0" } }, "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
@@ -1080,11 +985,13 @@
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
-    "pump": ["pump@3.0.2", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw=="],
-
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.2.0", "", {}, "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg=="],
 
     "queue-lit": ["queue-lit@1.5.2", "", {}, "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw=="],
 
@@ -1094,19 +1001,17 @@
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 
-    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
-
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "read-pkg": ["read-pkg@5.2.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.0", "normalize-package-data": "^2.5.0", "parse-json": "^5.0.0", "type-fest": "^0.6.0" } }, "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg=="],
 
     "read-pkg-up": ["read-pkg-up@7.0.1", "", { "dependencies": { "find-up": "^4.1.0", "read-pkg": "^5.2.0", "type-fest": "^0.8.1" } }, "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg=="],
 
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -1124,21 +1029,15 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
     "scale-ts": ["scale-ts@1.6.1", "", {}, "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g=="],
 
     "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
-
-    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1148,23 +1047,13 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
-
     "simple-wcswidth": ["simple-wcswidth@1.0.1", "", {}, "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
-    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
-
     "smoldot": ["smoldot@2.0.26", "", { "dependencies": { "ws": "^8.8.1" } }, "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig=="],
-
-    "socks": ["socks@2.8.5", "", { "dependencies": { "ip-address": "^9.0.5", "smart-buffer": "^4.2.0" } }, "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww=="],
-
-    "socks-proxy-agent": ["socks-proxy-agent@6.2.1", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -1182,17 +1071,11 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
-    "sqlite3": ["sqlite3@5.1.7", "", { "dependencies": { "bindings": "^1.5.0", "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.1", "tar": "^6.1.11" }, "optionalDependencies": { "node-gyp": "8.x" } }, "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog=="],
-
-    "ssri": ["ssri@8.0.1", "", { "dependencies": { "minipass": "^3.1.1" } }, "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ=="],
-
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1211,12 +1094,6 @@
     "supports-hyperlinks": ["supports-hyperlinks@2.3.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
-
-    "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
-
-    "tar-fs": ["tar-fs@2.1.3", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg=="],
-
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
 
@@ -1240,7 +1117,7 @@
 
     "tsx": ["tsx@4.20.5", "", { "dependencies": { "esbuild": "~0.25.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw=="],
 
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "turbo": ["turbo@2.5.4", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.4", "turbo-darwin-arm64": "2.5.4", "turbo-linux-64": "2.5.4", "turbo-linux-arm64": "2.5.4", "turbo-windows-64": "2.5.4", "turbo-windows-arm64": "2.5.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA=="],
 
@@ -1270,15 +1147,9 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "unique-filename": ["unique-filename@1.1.1", "", { "dependencies": { "unique-slug": "^2.0.0" } }, "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ=="],
-
-    "unique-slug": ["unique-slug@2.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w=="],
-
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
     "utf8": ["utf8@3.0.0", "", {}, "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="],
-
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
@@ -1286,7 +1157,7 @@
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
-    "viem": ["viem@2.31.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.7.1", "ws": "8.18.2" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA=="],
+    "viem": ["viem@2.55.17", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.33", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-XKASpfG9jznxsU/J7Bj2k9aS0UZgU3sBcwVoQ6slD5T1RmNJHh3khmFVJuRKjrOe3uqHb0FJKbb6jwE49WtVDQ=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
@@ -1296,8 +1167,6 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wide-align": ["wide-align@1.1.5", "", { "dependencies": { "string-width": "^1.0.2 || 2 || 3 || 4" } }, "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg=="],
-
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -1306,11 +1175,11 @@
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.8.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ=="],
 
@@ -1326,13 +1195,13 @@
 
     "@0xgasless/agentkit/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@0xgasless/smart-account-sdk/merkletreejs": ["merkletreejs@0.3.11", "", { "dependencies": { "bignumber.js": "^9.0.1", "buffer-reverse": "^1.0.1", "crypto-js": "^4.2.0", "treeify": "^1.1.0", "web3-utils": "^1.3.4" } }, "sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "@polkadot/x-ws/ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
 
     "@scure/sr25519/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
@@ -1342,13 +1211,15 @@
 
     "@types/bn.js/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
+    "@zkp2p/cash/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@zkp2p/contracts-v2/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
+    "@zkp2p/sdk/ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
+
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
-
-    "cacache/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "camelcase-keys/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
@@ -1380,13 +1251,9 @@
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
-    "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
     "glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "ip-address/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1394,39 +1261,19 @@
 
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "make-fetch-happen/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
-
-    "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
     "meow/type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
 
     "meow/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
-
-    "minipass-collect/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-fetch/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
-
-    "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "number-to-bn/bn.js": ["bn.js@4.11.6", "", {}, "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="],
 
     "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
 
+    "ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
+
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
-
-    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "^2.1.4", "resolve": "^1.10.0", "semver": "2 || 3 || 4 || 5", "validate-npm-package-license": "^3.0.1" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
 
@@ -1434,17 +1281,23 @@
 
     "read-pkg-up/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
 
-    "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+    "smoldot/ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
 
     "supports-hyperlinks/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
-
     "test-exclude/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
+    "viem/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@types/bn.js/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "@zkp2p/sdk/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
+
+    "@zkp2p/sdk/ox/abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1455,6 +1308,8 @@
     "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "jake/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@storagehub-sdk/core": "^0.4.0",
         "@storagehub-sdk/msp-client": "^0.4.0",
         "@storagehub/api-augment": "^0.2.14",
-        "@zkp2p/cash": "^0.4.9",
+        "@zkp2p/cash": "0.4.9",
         "axios": "^1.7.9",
         "viem": "2",
         "zod": "^3.23.8",


### PR DESCRIPTION
Implements #32. Adds eight Peer Cash actions so an agent can turn its Base USDC into fiat.

Peer Cash is an offramp protocol on Base. The agent's wallet is the maker: its USDC becomes a protocol-held order, a buyer pays fiat to the agent's own Venmo, Revolut, Wise, Zelle, PayPal, Cash App, Chime, or Monzo handle and proves the payment with TEE-TLS, and the escrow releases the USDC at the live Chainlink oracle rate with zero spread.

- Package: `@zkp2p/cash`, MIT, https://github.com/zkp2p/peer-cash
- Docs: https://docs.peer.xyz/developer/peer-cash

#32 asks whether you want prepare-only or an additional signing verb. This PR is the prepare-only shape. If you would rather have a one-shot `peer_cash_cashout` that submits through `wallet.sendTransaction`, say so on the issue and I will add it here.

## Custody

Every mutating verb returns UNSIGNED `{ to, data, value, chainId }` for `send_transaction` to submit. No action in this PR accepts, reads, derives, or stores a private key, and `@zkp2p/cash` exposes no signing path in the surface these actions use. The order belongs to whichever address submits the transactions.

## Files

`agentkit-core/src/actions/PeerCashAction/`

| File | Action | What it does |
|---|---|---|
| `client.ts` | | shared client, typed error formatting, USDC amount parsing |
| `capabilities.ts` | `peer_cash_capabilities` | platforms, currencies, payee formats, amount bounds |
| `estimate.ts` | `peer_cash_estimate` | fiat at the live oracle rate, plus a 30-day median fill ETA |
| `prepareCashout.ts` | `peer_cash_prepare_cashout` | unsigned `[approve, createDeposit]` |
| `prepareAccessPolicy.ts` | `peer_cash_prepare_access_policy` | the follow-up Venmo, Cash App, and PayPal orders require |
| `order.ts` | `peer_cash_order` | one order's state, fills, and next actions |
| `orders.ts` | `peer_cash_orders` | orders for an address, defaulting to the agent's own |
| `prepareTopUp.ts` | `peer_cash_prepare_topup` | unsigned `[approve, addFunds]` |
| `prepareWithdraw.ts` | `peer_cash_prepare_withdraw` | unsigned transactions that unwind an order |
| `index.ts` | | barrel and `PEER_CASH_ACTIONS` |

All eight are `walletOptional: true` and `smartAccountRequired: false`, so they run in platform mode, self-custody mode, and with no wallet configured. `peer_cash_orders` is the only one that reads the wallet, and only to default the address.

Also changed:

- `agentkit-core/src/actions/index.ts`: registers `PEER_CASH_ACTIONS`.
- `agentkit-core/package.json`: adds `@zkp2p/cash`, and runs the new smoke test from `test:smoke`.
- `agentkit-core/tsconfig.json`: `"target": "es2022"`. The newer `ox` that viem resolves to ships `.ts` sources needing `String.replaceAll` and the `Error` `cause` option, so `bun run check` fails at `es2020`. Scoped to this file rather than `tsconfig.base.json`.
- `agentkit-core/test/peer-cash.smoke.mjs`: new, in the style of `platform.smoke.mjs`.
- `bun.lock`.

## Test plan

- [x] `bun run check`: exit 0
- [x] `bun run build`: exit 0
- [x] `biome lint` and `biome check` on the new directory: clean
- [x] `bun run lint`: same 30 pre-existing errors as `main`, none in `PeerCashAction`
- [x] `bun run test:smoke`: both `PLATFORM SMOKE` and `PEER CASH SMOKE` pass
- [x] `PEER_CASH_SMOKE_LIVE=1 node test/peer-cash.smoke.mjs`: passes against Peer production

The new smoke test is offline by default, covering registration, wallet-optional dispatch, argument schemas, and the typed error surface. `PEER_CASH_SMOKE_LIVE=1` adds production reads and one unsigned cash-out plan; `PEER_CASH_SMOKE_ORDER_ID` adds order and list reads. It never signs or broadcasts.

Live results from `getAllAgentkitActions()` with no wallet configured: discovery returned 8 payout platforms across 13 currencies on chain 8453 at 0 bps spread; a 250 USDC estimate returned 215.67 EUR at 0.8627 with a 40 minute ETA; `peer_cash_prepare_cashout` returned `[approve, createDeposit]` both with `chainId: 8453`; `peer_cash_prepare_topup` returned `[approve, addFunds]`; `peer_cash_prepare_withdraw` returned a single `withdrawDeposit`; `peer_cash_prepare_access_policy` returned one transaction; a nonexistent order id returned `Error: Peer Cash order failed. [ORDER_NOT_FOUND] ... This error is retryable.`

## Notes

- Peer Cash settles on Base (8453) only, which is already in `supportedChains` with USDC in `tokenMappings`. Prepared transactions carry `chainId: 8453`, so submitting them needs an agent configured on Base. The read actions work on any chain.
- The client is constructed with `referrer: "0xgasless-agentkit"`, an ERC-8021 analytics marker appended to the calldata suffix beside the `peer-cash` marker the SDK adds regardless. It carries no funds and grants no permissions. Happy to drop it.
- `PEER_CASH_RPC_URL` overrides the public Base RPC, which is rate limited. `PEER_CASH_REFERRAL_CODE` is the operator's own six-character Peer code. Both are optional and read the same way `sxt.ts` reads `SXT_API_KEY`.
